### PR TITLE
[Refactor] Remove mg_int; make idx type a template argument

### DIFF
--- a/minigun/minigun/advance.h
+++ b/minigun/minigun/advance.h
@@ -52,7 +52,12 @@ struct Config {
   static const FrontierMode kMode = MODE;
 };
 
+/*!
+ * \brief Template specialization to dispatch to implementations
+ *        on different devices.
+ */
 template <int XPU,
+          typename Idx,
           typename Config,
           typename GData,
           typename Functor,
@@ -70,10 +75,11 @@ struct DispatchXPU {
 };
 
 
-/*
- * !\brief Advance kernel.
+/*!
+ * \brief Advance kernel.
  *
  * \tparam XPU The computing device type (DLDeviceType)
+ * \tparam Idx The type of the index (usually int32_t or int64_t)
  * \tparam Config The static configuration of advance kernel.
  * \tparam GData The user-defined graph data.
  * \tparam Functor The user-defined functions.
@@ -89,21 +95,22 @@ struct DispatchXPU {
  * \param alloc The external memory allocator.
  */
 template <int XPU,
+          typename Idx,
           typename Config,
           typename GData,
           typename Functor,
           typename Alloc = DefaultAllocator<XPU> >
 void Advance(const RuntimeConfig& config,
-             const Csr& csr,
+             const Csr<Idx>& csr,
              GData* gdata,
-             IntArray1D input_frontier,
-             IntArray1D* output_frontier = nullptr,
+             IntArray1D<Idx> input_frontier,
+             IntArray1D<Idx>* output_frontier = nullptr,
              Alloc* alloc = DefaultAllocator<XPU>::Get()) {
   if (Config::kMode != kV2N && Config::kMode != kE2N
       && output_frontier == nullptr) {
     LOG(FATAL) << "Require computing output frontier but no buffer is provided.";
   }
-  DispatchXPU<XPU, Config, GData, Functor, Alloc>::Advance(
+  DispatchXPU<XPU, Idx, Config, GData, Functor, Alloc>::Advance(
       config, csr, gdata,
       input_frontier, output_frontier, alloc);
 }

--- a/minigun/minigun/advance.h
+++ b/minigun/minigun/advance.h
@@ -65,10 +65,10 @@ template <int XPU,
 struct DispatchXPU {
   static void Advance(
       const RuntimeConfig& config,
-      const Csr& csr,
+      const Csr<Idx>& csr,
       GData* gdata,
-      IntArray1D input_frontier,
-      IntArray1D* output_frontier,
+      IntArray1D<Idx> input_frontier,
+      IntArray1D<Idx>* output_frontier,
       Alloc* alloc) {
     LOG(FATAL) << "Not implemented for XPU: " << XPU;
   }

--- a/minigun/minigun/base.h
+++ b/minigun/minigun/base.h
@@ -4,12 +4,10 @@
 #include <cstdint>
 #include <dmlc/logging.h>
 
-typedef int32_t mg_int;
-
 namespace minigun {
 
 // const for invalid frontier value
-static const mg_int kInvalid = -1;
+#define MG_INVALID -1
 
 }  // namespace minigun
 

--- a/minigun/minigun/cpu/advance.h
+++ b/minigun/minigun/cpu/advance.h
@@ -7,53 +7,53 @@
 namespace minigun {
 namespace advance {
 
-template <typename Alloc>
-mg_int ComputeOutputLength(Csr csr,
-                           IntArray1D input_frontier,
-                           IntArray1D* lcl_row_offsets,
-                           Alloc* alloc) {
-  IntArray1D edge_counts;
+template <typename Idx, typename Alloc>
+Idx ComputeOutputLength(Csr<Idx> csr,
+                        IntArray1D<Idx> input_frontier,
+                        IntArray1D<Idx>* lcl_row_offsets,
+                        Alloc* alloc) {
+  IntArray1D<Idx> edge_counts;
   lcl_row_offsets->data[0] = 0;
   edge_counts.length = input_frontier.length;
-  edge_counts.data = alloc->template AllocateWorkspace<mg_int>(
-      edge_counts.length * sizeof(mg_int));
+  edge_counts.data = alloc->template AllocateWorkspace<Idx>(
+      edge_counts.length * sizeof(Idx));
 #pragma omp parallel for
-  for (mg_int tid = 0; tid < edge_counts.length; ++tid) {
-    const mg_int vid = input_frontier.data[tid];
+  for (Idx tid = 0; tid < edge_counts.length; ++tid) {
+    const Idx vid = input_frontier.data[tid];
     edge_counts.data[tid] = csr.row_offsets.data[vid + 1] -
       csr.row_offsets.data[vid];
   }
 
   // prefix sum with openmp
-  mg_int* thread_sum;
+  Idx* thread_sum;
 #pragma omp parallel
   {
-    const mg_int tid = omp_get_thread_num();
-    const mg_int ntr = omp_get_num_threads();
+    const Idx tid = omp_get_thread_num();
+    const Idx ntr = omp_get_num_threads();
 
     // only one thread should allocate workspace
 #pragma omp single
     {
-      thread_sum = alloc->template AllocateWorkspace<mg_int>(ntr *
-          sizeof(mg_int));
+      thread_sum = alloc->template AllocateWorkspace<Idx>(ntr *
+          sizeof(Idx));
     }
 
     // each thread calculates one chunk of partial sum
-    mg_int sum = 0;
+    Idx sum = 0;
 #pragma omp for schedule(static)
-    for (mg_int vid = 0; vid < edge_counts.length; ++vid) {
+    for (Idx vid = 0; vid < edge_counts.length; ++vid) {
       sum += edge_counts.data[vid];
       lcl_row_offsets->data[vid + 1] = sum;
     }
     thread_sum[tid] = sum;
 #pragma omp barrier
     // fix partial sum in each chunk by adding offsets
-    mg_int offset = 0;
-    for (mg_int i = 0; i < tid; ++i) {
+    Idx offset = 0;
+    for (Idx i = 0; i < tid; ++i) {
       offset += thread_sum[i];
     }
 #pragma omp for schedule(static)
-    for (mg_int vid = 0; vid < edge_counts.length; ++vid) {
+    for (Idx vid = 0; vid < edge_counts.length; ++vid) {
       lcl_row_offsets->data[vid + 1] += offset;
     }
   }
@@ -63,37 +63,33 @@ mg_int ComputeOutputLength(Csr csr,
   return lcl_row_offsets->data[edge_counts.length];
 }
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor,
           typename Alloc>
-void CPUAdvance(Csr csr,
+void CPUAdvance(Csr<Idx> csr,
                 GData* gdata,
-                IntArray1D input_frontier,
-                IntArray1D output_frontier,
-                IntArray1D lcl_row_offsets,
+                IntArray1D<Idx> input_frontier,
+                IntArray1D<Idx> output_frontier,
+                IntArray1D<Idx> lcl_row_offsets,
                 Alloc* alloc) {
-  mg_int N;
-  if (Config::kAdvanceAll) {
-    N = csr.row_offsets.length - 1;
-  } else {
-    N = input_frontier.length;
-  }
+  Idx N = Config::kAdvanceAll ? csr.row_offsets.length - 1 : input_frontier.length;
 #pragma omp parallel for
-  for (mg_int vid = 0; vid < N; ++vid) {
-    mg_int src = vid;
+  for (Idx vid = 0; vid < N; ++vid) {
+    Idx src = vid;
     if (!Config::kAdvanceAll) {
       src = input_frontier.data[vid];
     }
-    const mg_int row_start = csr.row_offsets.data[src];
-    const mg_int row_end = csr.row_offsets.data[src + 1];
-    for (mg_int eid = row_start; eid < row_end; ++eid) {
-      const mg_int dst = csr.column_indices.data[eid];
+    const Idx row_start = csr.row_offsets.data[src];
+    const Idx row_end = csr.row_offsets.data[src + 1];
+    for (Idx eid = row_start; eid < row_end; ++eid) {
+      const Idx dst = csr.column_indices.data[eid];
       if (Functor::CondEdge(src, dst, eid, gdata)) {
         Functor::ApplyEdge(src, dst, eid, gdata);
         if (Config::kMode != kV2N && Config::kMode != kE2N) {
 
-          mg_int out_idx;
+          Idx out_idx;
           if (Config::kAdvanceAll) {
             out_idx = eid;
           } else {
@@ -107,46 +103,47 @@ void CPUAdvance(Csr csr,
         }
       } else {
         if (Config::kMode != kV2N && Config::kMode != kE2N) {
-          mg_int out_idx;
+          Idx out_idx;
           if (Config::kAdvanceAll) {
             out_idx = eid;
           } else {
             out_idx = eid - row_start + lcl_row_offsets.data[vid];
           }
-          output_frontier.data[out_idx] = kInvalid;
+          output_frontier.data[out_idx] = MG_INVALID;
         }
       }
     }
   }
 }
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor,
           typename Alloc>
-struct DispatchXPU<kDLCPU, Config, GData, Functor, Alloc> {
+struct DispatchXPU<kDLCPU, Idx, Config, GData, Functor, Alloc> {
   static void Advance(
       const RuntimeConfig& rtcfg,
-      const Csr& csr,
+      const Csr<Idx>& csr,
       GData* gdata,
-      IntArray1D input_frontier,
-      IntArray1D* output_frontier,
+      IntArray1D<Idx> input_frontier,
+      IntArray1D<Idx>* output_frontier,
       Alloc* alloc) {
     if (Config::kMode != kV2V && Config::kMode != kV2E
         && Config::kMode != kV2N) {
       LOG(FATAL) << "Advance from edge not supported for CPU";
     }
-    IntArray1D lcl_row_offsets;
-    mg_int out_len = 0;
+    IntArray1D<Idx> lcl_row_offsets;
+    Idx out_len = 0;
     if (Config::kAdvanceAll) {
       lcl_row_offsets = csr.row_offsets;
       out_len = csr.column_indices.length;
     } else {
       if (Config::kMode != kV2N && Config::kMode != kE2N) {
         lcl_row_offsets.length = input_frontier.length + 1;
-        lcl_row_offsets.data = alloc->template AllocateWorkspace<mg_int>(
-            lcl_row_offsets.length * sizeof(mg_int));
-        out_len = ComputeOutputLength<Alloc>(
+        lcl_row_offsets.data = alloc->template AllocateWorkspace<Idx>(
+            lcl_row_offsets.length * sizeof(Idx));
+        out_len = ComputeOutputLength(
             csr, input_frontier, &lcl_row_offsets, alloc);
       }
     }
@@ -154,8 +151,8 @@ struct DispatchXPU<kDLCPU, Config, GData, Functor, Alloc> {
       if (output_frontier->data == nullptr) {
         // The output frontier buffer should be allocated.
         output_frontier->length = out_len;
-        output_frontier->data = alloc->template AllocateData<mg_int>(
-            output_frontier->length * sizeof(mg_int));
+        output_frontier->data = alloc->template AllocateData<Idx>(
+            output_frontier->length * sizeof(Idx));
       } else {
         CHECK_GE(output_frontier->length, out_len)
           << "Require output frontier of length " << out_len
@@ -163,8 +160,8 @@ struct DispatchXPU<kDLCPU, Config, GData, Functor, Alloc> {
       }
     }
 
-    IntArray1D outbuf = (output_frontier)? *output_frontier : IntArray1D();
-    CPUAdvance<Config, GData, Functor, Alloc>(
+    IntArray1D<Idx> outbuf = (output_frontier)? *output_frontier : IntArray1D<Idx>();
+    CPUAdvance<Idx, Config, GData, Functor, Alloc>(
         csr, gdata, input_frontier, outbuf, lcl_row_offsets, alloc);
 
     if (!Config::kAdvanceAll && Config::kMode != kV2N

--- a/minigun/minigun/csr.h
+++ b/minigun/minigun/csr.h
@@ -11,7 +11,7 @@ namespace minigun {
 template <typename Idx>
 struct IntArray1D {
   Idx* data = nullptr;
-  int64_t length = 0;
+  Idx length = 0;
 };
 
 using IntArray = IntArray1D<int32_t>;

--- a/minigun/minigun/csr.h
+++ b/minigun/minigun/csr.h
@@ -8,16 +8,24 @@ namespace minigun {
 
 // NOTE: minigun does not own any memory
 
+template <typename Idx>
 struct IntArray1D {
-  mg_int* data = nullptr;
-  mg_int length = 0;
+  Idx* data = nullptr;
+  int64_t length = 0;
 };
 
+using IntArray = IntArray1D<int32_t>;
+using LongArray = IntArray1D<int64_t>;
+
 // edges of node i are stored in column_indices[row_offsets[i]:row_offsets[i+1]]
+template <typename Idx>
 struct Csr {
-  IntArray1D row_offsets;  // len == num_nodes + 1
-  IntArray1D column_indices;  // len == num_edges
+  IntArray1D<Idx> row_offsets;  // len == num_nodes + 1
+  IntArray1D<Idx> column_indices;  // len == num_edges
 };
+
+using IntCsr = Csr<int32_t>;
+using LongCsr = Csr<int64_t>;
 
 }  // namespace minigun
 

--- a/minigun/minigun/cuda/advance.cuh
+++ b/minigun/minigun/cuda/advance.cuh
@@ -17,23 +17,25 @@ namespace advance {
 #define MAX_NTHREADS 1024
 #define MAX_NBLOCKS 65535
 
+template <typename Idx>
 struct StridedIterator :
-  mgpu::const_iterator_t<StridedIterator, int, mg_int> {
+  mgpu::const_iterator_t<StridedIterator, int, Idx> {
 
   StridedIterator() = default;
-  MGPU_HOST_DEVICE StridedIterator(mg_int offset, mg_int stride, mg_int bound) :
-    mgpu::const_iterator_t<StridedIterator, int, mg_int>(0),
+  MGPU_HOST_DEVICE StridedIterator(Idx offset, Idx stride, Idx bound) :
+    mgpu::const_iterator_t<StridedIterator, int, Idx>(0),
     offset_(offset), stride_(stride), bound_(bound) { }
 
-  MGPU_HOST_DEVICE mg_int operator()(int index) const {
-    mg_int ret = offset_ + index * stride_;
+  MGPU_HOST_DEVICE Idx operator()(int index) const {
+    Idx ret = offset_ + index * stride_;
     return (ret < bound_) ? ret : bound_;
   }
 
-  mg_int offset_, stride_, bound_;
+  Idx offset_, stride_, bound_;
 };
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor,
           typename Alloc>
@@ -42,10 +44,10 @@ class CudaAdvanceExecutor {
   CudaAdvanceExecutor(
       AdvanceAlg algo,
       const RuntimeConfig& rtcfg,
-      const Csr& csr,
+      const Csr<Idx>& csr,
       GData* gdata,
-      IntArray1D input_frontier,
-      IntArray1D* output_frontier,
+      IntArray1D<Idx> input_frontier,
+      IntArray1D<Idx>* output_frontier,
       Alloc* alloc):
     algo_(algo), rtcfg_(rtcfg), csr_(csr), gdata_(gdata),
     input_frontier_(input_frontier), output_frontier_(output_frontier),
@@ -56,15 +58,15 @@ class CudaAdvanceExecutor {
     // Row offset array of local graph (graph sliced by nodes in input_frontier).
     // It's length == len(input_frontier) + 1, and
     // lcl_row_offsets[i+1] - lcl_row_offsets[i] == edge_counts[i]
-    IntArray1D lcl_row_offsets;
+    IntArray1D<Idx> lcl_row_offsets;
 
     if (Config::kAdvanceAll) {
       lcl_row_offsets = csr_.row_offsets;
       out_len_ = csr_.column_indices.length;
     } else {
       lcl_row_offsets.length = input_frontier_.length + 1;
-      lcl_row_offsets.data = alloc_->template AllocateWorkspace<mg_int>(
-          lcl_row_offsets.length * sizeof(mg_int));
+      lcl_row_offsets.data = alloc_->template AllocateWorkspace<Idx>(
+          lcl_row_offsets.length * sizeof(Idx));
       out_len_ = ComputeOutputLength(mgpuctx, &lcl_row_offsets);
     }
 
@@ -72,8 +74,8 @@ class CudaAdvanceExecutor {
       if (output_frontier_->data == nullptr) {
         // The output frontier buffer should be allocated.
         output_frontier_->length = out_len_;
-        output_frontier_->data = alloc_->template AllocateData<mg_int>(
-            output_frontier_->length * sizeof(mg_int));
+        output_frontier_->data = alloc_->template AllocateData<Idx>(
+            output_frontier_->length * sizeof(Idx));
       } else {
         CHECK_GE(output_frontier_->length, out_len_)
           << "Require output frontier of length " << out_len_
@@ -94,16 +96,16 @@ class CudaAdvanceExecutor {
     }
   }
 
-  mg_int ComputeOutputLength(MgpuContext<Alloc>& mgpuctx, IntArray1D* lcl_row_offsets) {
+  Idx ComputeOutputLength(MgpuContext<Alloc>& mgpuctx, IntArray1D<Idx>* lcl_row_offsets) {
     // An array of size len(input_frontier). Each element i is the number of
     // edges input_frointer[i] has.
-    IntArray1D edge_counts;
+    IntArray1D<Idx> edge_counts;
     edge_counts.length = input_frontier_.length;
-    edge_counts.data = alloc_->template AllocateWorkspace<mg_int>(
-        edge_counts.length * sizeof(mg_int));
+    edge_counts.data = alloc_->template AllocateWorkspace<Idx>(
+        edge_counts.length * sizeof(Idx));
     mgpu::transform(
-      [] MGPU_DEVICE(int tid, const mg_int* rowoff, const mg_int* infront, mg_int* ecounts) {
-        const mg_int vid = infront[tid];
+      [] MGPU_DEVICE(int tid, const Idx* rowoff, const Idx* infront, Idx* ecounts) {
+        const Idx vid = infront[tid];
         ecounts[tid] = rowoff[vid + 1] - rowoff[vid];
       }, edge_counts.length, mgpuctx,
       csr_.row_offsets.data,
@@ -114,71 +116,71 @@ class CudaAdvanceExecutor {
         edge_counts.data,
         edge_counts.length,
         lcl_row_offsets->data,
-        mgpu::plus_t<mg_int>(),
+        mgpu::plus_t<Idx>(),
         lcl_row_offsets->data + edge_counts.length,  // the last element stores the reduction.
         mgpuctx);
     //// get the reduction
-    mg_int outlen;
+    Idx outlen;
     CUDA_CALL(cudaMemcpy(&outlen, lcl_row_offsets->data + edge_counts.length,
-          sizeof(mg_int), cudaMemcpyDeviceToHost));
+          sizeof(Idx), cudaMemcpyDeviceToHost));
     //LOG(INFO) << "Output frontier length: " << *outlen;
     alloc_->FreeWorkspace(edge_counts.data);
     return outlen;
   }
 
-  void CudaAdvanceGunrockLBOut(MgpuContext<Alloc>& mgpuctx, IntArray1D lcl_row_offsets) {
+  void CudaAdvanceGunrockLBOut(MgpuContext<Alloc>& mgpuctx, IntArray1D<Idx> lcl_row_offsets) {
     // partition the workload
-    const mg_int M = out_len_;
+    const Idx M = out_len_;
     const int ty = MAX_NTHREADS / rtcfg_.data_num_threads;
     const int ny = ty * 2;  // XXX: each block handles two partitions
-    const int by = std::min((M + ny - 1) / ny, static_cast<mg_int>(MAX_NBLOCKS));
+    const int by = std::min((M + ny - 1) / ny, static_cast<Idx>(MAX_NBLOCKS));
     const int nparts_per_blk = ((M + by - 1) / by + ty - 1) / ty;
     const dim3 nblks(rtcfg_.data_num_blocks, by);
     const dim3 nthrs(rtcfg_.data_num_threads, ty);
     //LOG(INFO) << "Blocks: (" << nblks.x << "," << nblks.y << ") Threads: ("
     //  << nthrs.x << "," << nthrs.y << ")" << " nparts_per_blk=" << nparts_per_blk;
     // use sorted search to compute the partition_starts 
-    IntArray1D partition_starts;
+    IntArray1D<Idx> partition_starts;
     partition_starts.length = (M + ty - 1) / ty + 1;
-    partition_starts.data = alloc_->template AllocateWorkspace<mg_int>(
-        partition_starts.length * sizeof(mg_int));
+    partition_starts.data = alloc_->template AllocateWorkspace<Idx>(
+        partition_starts.length * sizeof(Idx));
     mgpu::sorted_search<mgpu::bounds_lower>(
-        StridedIterator(0, ty, out_len_),
+        StridedIterator<Idx>(0, ty, out_len_),
         partition_starts.length,
         lcl_row_offsets.data,
         lcl_row_offsets.length,
         partition_starts.data,
-        mgpu::less_t<mg_int>(),
+        mgpu::less_t<Idx>(),
         mgpuctx);
 
-    IntArray1D outbuf = (output_frontier_)? *output_frontier_ : IntArray1D();
+    IntArray1D<Idx> outbuf = (output_frontier_)? *output_frontier_ : IntArray1D<Idx>();
     if (ty > 512) {
-      CUDAAdvanceLBKernel<1024, Config, GData, Functor>
+      CUDAAdvanceLBKernel<1024, Idx, Config, GData, Functor>
         <<<nblks, nthrs, 0, rtcfg_.stream>>>(
             csr_, *gdata_, input_frontier_, outbuf,
             lcl_row_offsets, nparts_per_blk, partition_starts);
     } else if (ty > 256) {
-      CUDAAdvanceLBKernel<512, Config, GData, Functor>
+      CUDAAdvanceLBKernel<512, Idx, Config, GData, Functor>
         <<<nblks, nthrs, 0, rtcfg_.stream>>>(
             csr_, *gdata_, input_frontier_, outbuf,
             lcl_row_offsets, nparts_per_blk, partition_starts);
     } else if (ty > 128) {
-      CUDAAdvanceLBKernel<256, Config, GData, Functor>
+      CUDAAdvanceLBKernel<256, Idx, Config, GData, Functor>
         <<<nblks, nthrs, 0, rtcfg_.stream>>>(
             csr_, *gdata_, input_frontier_, outbuf,
             lcl_row_offsets, nparts_per_blk, partition_starts);
     } else if (ty > 64) {
-      CUDAAdvanceLBKernel<128, Config, GData, Functor>
+      CUDAAdvanceLBKernel<128, Idx, Config, GData, Functor>
         <<<nblks, nthrs, 0, rtcfg_.stream>>>(
             csr_, *gdata_, input_frontier_, outbuf,
             lcl_row_offsets, nparts_per_blk, partition_starts);
     } else if (ty > 32) {
-      CUDAAdvanceLBKernel<64, Config, GData, Functor>
+      CUDAAdvanceLBKernel<64, Idx, Config, GData, Functor>
         <<<nblks, nthrs, 0, rtcfg_.stream>>>(
             csr_, *gdata_, input_frontier_, outbuf,
             lcl_row_offsets, nparts_per_blk, partition_starts);
     } else {
-      CUDAAdvanceLBKernel<32, Config, GData, Functor>
+      CUDAAdvanceLBKernel<32, Idx, Config, GData, Functor>
         <<<nblks, nthrs, 0, rtcfg_.stream>>>(
             csr_, *gdata_, input_frontier_, outbuf,
             lcl_row_offsets, nparts_per_blk, partition_starts);
@@ -190,37 +192,38 @@ class CudaAdvanceExecutor {
  private:
   const AdvanceAlg algo_;
   const RuntimeConfig& rtcfg_;
-  const Csr& csr_;
+  const Csr<Idx>& csr_;
   GData* gdata_;
-  IntArray1D input_frontier_;
-  IntArray1D* output_frontier_;
+  IntArray1D<Idx> input_frontier_;
+  IntArray1D<Idx>* output_frontier_;
   Alloc* alloc_;
 
   // size of the output frontier
-  mg_int out_len_ = 0;
+  Idx out_len_ = 0;
 };
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor,
           typename Alloc>
-struct DispatchXPU<kDLGPU, Config, GData, Functor, Alloc> {
+struct DispatchXPU<kDLGPU, Idx, Config, GData, Functor, Alloc> {
   static void Advance(
       const RuntimeConfig& rtcfg,
-      const Csr& csr,
+      const Csr<Idx>& csr,
       GData* gdata,
-      IntArray1D input_frontier,
-      IntArray1D* output_frontier,
+      IntArray1D<Idx> input_frontier,
+      IntArray1D<Idx>* output_frontier,
       Alloc* alloc) {
     // Call advance
     if (Config::kAdvanceAll) {
-      AdvanceAlg algo = FindAdvanceAllAlgo<Config>(rtcfg, csr);
-      CudaAdvanceAll<Config, GData, Functor, Alloc>(
+      AdvanceAlg algo = FindAdvanceAllAlgo<Idx, Config>(rtcfg, csr);
+      CudaAdvanceAll<Idx, Config, GData, Functor, Alloc>(
           algo, rtcfg, csr, gdata, output_frontier, alloc);
     } else {
-      AdvanceAlg algo = FindAdvanceAlgo<Config>(rtcfg, csr,
+      AdvanceAlg algo = FindAdvanceAlgo<Idx, Config>(rtcfg, csr,
           input_frontier);
-      CudaAdvanceExecutor<Config, GData, Functor, Alloc> exec(
+      CudaAdvanceExecutor<Idx, Config, GData, Functor, Alloc> exec(
           algo, rtcfg, csr, gdata, input_frontier, output_frontier, alloc);
       exec.Run();
     }

--- a/minigun/minigun/cuda/advance.cuh
+++ b/minigun/minigun/cuda/advance.cuh
@@ -19,7 +19,7 @@ namespace advance {
 
 template <typename Idx>
 struct StridedIterator :
-  mgpu::const_iterator_t<StridedIterator, int, Idx> {
+  mgpu::const_iterator_t<StridedIterator<Idx>, int, Idx> {
 
   StridedIterator() = default;
   MGPU_HOST_DEVICE StridedIterator(Idx offset, Idx stride, Idx bound) :

--- a/minigun/minigun/cuda/advance_all.cuh
+++ b/minigun/minigun/cuda/advance_all.cuh
@@ -115,7 +115,7 @@ void CudaAdvanceAll(
         << " but only got a buffer of length " << output_frontier->length;
     }
   }
-  IntArray1D outbuf = (output_frontier)? *output_frontier : IntArray1D();
+  IntArray1D<Idx> outbuf = (output_frontier)? *output_frontier : IntArray1D<Idx>();
   switch (algo) {
     case kGunrockLBOut :
       CudaAdvanceAllGunrockLBOut<Idx, Config, GData, Functor, Alloc>(

--- a/minigun/minigun/cuda/advance_all.cuh
+++ b/minigun/minigun/cuda/advance_all.cuh
@@ -11,10 +11,11 @@ namespace advance {
 #define MAX_NBLOCKS 65535
 
 // Binary search the row_offsets to find the source node of the edge id.
-__device__ __forceinline__ mg_int BinarySearchSrc(const IntArray1D& array, mg_int eid) {
-  mg_int lo = 0, hi = array.length - 1;
+template <typename Idx>
+__device__ __forceinline__ Idx BinarySearchSrc(const IntArray1D<Idx>& array, Idx eid) {
+  Idx lo = 0, hi = array.length - 1;
   while (lo < hi) {
-    mg_int mid = (lo + hi) >> 1;
+    Idx mid = (lo + hi) >> 1;
     if (_ldg(array.data + mid) <= eid) {
       lo = mid + 1;
     } else {
@@ -29,21 +30,22 @@ __device__ __forceinline__ mg_int BinarySearchSrc(const IntArray1D& array, mg_in
   }
 }
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor>
 __global__ void CudaAdvanceAllGunrockLBOutKernel(
-    Csr csr,
+    Csr<Idx> csr,
     GData gdata,
-    IntArray1D output_frontier) {
-  mg_int ty = blockIdx.y * blockDim.y + threadIdx.y;
-  mg_int stride_y = blockDim.y * gridDim.y;
-  mg_int eid = ty;
+    IntArray1D<Idx> output_frontier) {
+  Idx ty = blockIdx.y * blockDim.y + threadIdx.y;
+  Idx stride_y = blockDim.y * gridDim.y;
+  Idx eid = ty;
   while (eid < csr.column_indices.length) {
     // TODO(minjie): this is pretty inefficient; binary search is needed only
     //   when the thread is processing the neighbor list of a new node.
-    mg_int src = BinarySearchSrc(csr.row_offsets, eid);
-    mg_int dst = _ldg(csr.column_indices.data + eid);
+    Idx src = BinarySearchSrc(csr.row_offsets, eid);
+    Idx dst = _ldg(csr.column_indices.data + eid);
     if (Functor::CondEdge(src, dst, eid, &gdata)) {
       Functor::ApplyEdge(src, dst, eid, &gdata);
       // Add dst/eid to output frontier
@@ -55,56 +57,58 @@ __global__ void CudaAdvanceAllGunrockLBOutKernel(
     } else {
       if (Config::kMode != kV2N && Config::kMode != kE2N) {
         // Add invalid to output frontier
-        output_frontier.data[eid] = kInvalid;
+        output_frontier.data[eid] = MG_INVALID;
       }
     }
     eid += stride_y;
   }
 };
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor,
           typename Alloc>
 void CudaAdvanceAllGunrockLBOut(
     const RuntimeConfig& rtcfg,
-    const Csr& csr,
+    const Csr<Idx>& csr,
     GData* gdata,
-    IntArray1D output_frontier,
+    IntArray1D<Idx> output_frontier,
     Alloc* alloc) {
   CHECK_GT(rtcfg.data_num_blocks, 0);
   CHECK_GT(rtcfg.data_num_threads, 0);
-  const mg_int M = csr.column_indices.length;
+  const Idx M = csr.column_indices.length;
   const int ty = MAX_NTHREADS / rtcfg.data_num_threads;
   const int ny = ty * PER_THREAD_WORKLOAD;
-  const int by = std::min((M + ny - 1) / ny, static_cast<mg_int>(MAX_NBLOCKS));
+  const int by = std::min((M + ny - 1) / ny, static_cast<Idx>(MAX_NBLOCKS));
   const dim3 nblks(rtcfg.data_num_blocks, by);
   const dim3 nthrs(rtcfg.data_num_threads, ty);
   //LOG(INFO) << "Blocks: (" << nblks.x << "," << nblks.y << ") Threads: ("
     //<< nthrs.x << "," << nthrs.y << ")";
-  CudaAdvanceAllGunrockLBOutKernel<Config, GData, Functor>
+  CudaAdvanceAllGunrockLBOutKernel<Idx, Config, GData, Functor>
     <<<nblks, nthrs, 0, rtcfg.stream>>>(csr, *gdata, output_frontier);
 }
 
-template <typename Config,
+template <typename Idx,
+          typename Config,
           typename GData,
           typename Functor,
           typename Alloc>
 void CudaAdvanceAll(
     AdvanceAlg algo,
     const RuntimeConfig& rtcfg,
-    const Csr& csr,
+    const Csr<Idx>& csr,
     GData* gdata,
-    IntArray1D* output_frontier,
+    IntArray1D<Idx>* output_frontier,
     Alloc* alloc) {
-  mg_int out_len = csr.column_indices.length;
+  Idx out_len = csr.column_indices.length;
   if (output_frontier) {
     if (output_frontier->data == nullptr) {
       // Allocate output frointer buffer, the length is equal to the number
       // of edges.
       output_frontier->length = out_len;
-      output_frontier->data = alloc->template AllocateData<mg_int>(
-          output_frontier->length * sizeof(mg_int));
+      output_frontier->data = alloc->template AllocateData<Idx>(
+          output_frontier->length * sizeof(Idx));
     } else {
       CHECK_GE(output_frontier->length, out_len)
         << "Require output frontier of length " << out_len
@@ -114,7 +118,7 @@ void CudaAdvanceAll(
   IntArray1D outbuf = (output_frontier)? *output_frontier : IntArray1D();
   switch (algo) {
     case kGunrockLBOut :
-      CudaAdvanceAllGunrockLBOut<Config, GData, Functor, Alloc>(
+      CudaAdvanceAllGunrockLBOut<Idx, Config, GData, Functor, Alloc>(
           rtcfg, csr, gdata, outbuf, alloc);
       break;
     default:

--- a/minigun/minigun/cuda/advance_lb.cuh
+++ b/minigun/minigun/cuda/advance_lb.cuh
@@ -60,8 +60,7 @@ __global__ void CUDAAdvanceLBKernel(
 
   Idx blk_out_start = blockDim.y * nparts_per_blk * blockIdx.y;
   Idx part_idx = blockIdx.y * nparts_per_blk;
-  const Idx loop_end = min(partition_starts.length - 1,
-                              part_idx + nparts_per_blk);
+  const Idx loop_end = min(partition_starts.length - 1, part_idx + nparts_per_blk);
   while (part_idx < loop_end) {
     // cooperatively load row offsets into load shared mem
     // each thread is in charge of one vertex

--- a/minigun/minigun/cuda/tuning.h
+++ b/minigun/minigun/cuda/tuning.h
@@ -6,19 +6,19 @@
 namespace minigun {
 namespace advance {
 
-template <typename Config>
+template <typename Idx, typename Config>
 AdvanceAlg FindAdvanceAllAlgo(
     const RuntimeConfig& rtcfg,
-    const Csr& csr) {
+    const Csr<Idx>& csr) {
   // TODO(minjie): more
   return kGunrockLBOut;
 }
 
-template <typename Config>
+template <typename Idx, typename Config>
 AdvanceAlg FindAdvanceAlgo(
     const RuntimeConfig& rtcfg,
-    const Csr& csr,
-    const IntArray1D& input_frontier) {
+    const Csr<Idx>& csr,
+    const IntArray1D<Idx>& input_frontier) {
   // TODO(minjie): more
   return kGunrockLBOut;
 }

--- a/samples/benchmark/bench_spmm.cu
+++ b/samples/benchmark/bench_spmm.cu
@@ -13,8 +13,8 @@ using minigun::advance::RuntimeConfig;
 using namespace spmm;
 
 double RunMinigun(const utils::SampleCsr& scsr,
-                  const minigun::Csr& csr,
-                  mg_int feat_size, mg_int num_heads) {
+                  const minigun::IntCsr& csr,
+                  int32_t feat_size, int32_t num_heads) {
   // gdata
   GData gdata, truth;
   gdata.D = feat_size;
@@ -30,11 +30,11 @@ double RunMinigun(const utils::SampleCsr& scsr,
   rtcfg.data_num_blocks = (gdata.H * gdata.D + (nt * 4) - 1) / (nt * 4);
   CUDA_CALL(cudaStreamCreate(&rtcfg.stream));
 
-  minigun::IntArray1D infront;
+  minigun::IntArray infront;
 
   // dry run
   typedef minigun::advance::Config<true, minigun::advance::kV2N> Config;
-  minigun::advance::Advance<kDLGPU, Config, GData, SPMMFunctor>(
+  minigun::advance::Advance<kDLGPU, int32_t, Config, GData, SPMMFunctor>(
       rtcfg, csr, &gdata, infront);
   CUDA_CALL(cudaDeviceSynchronize());
   CheckResult(scsr, &gdata, &truth);
@@ -43,7 +43,7 @@ double RunMinigun(const utils::SampleCsr& scsr,
   timeval t0, t1;
   gettimeofday(&t0, nullptr);
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLGPU, Config, GData, SPMMFunctor>(
+    minigun::advance::Advance<kDLGPU, int32_t, Config, GData, SPMMFunctor>(
         rtcfg, csr, &gdata, infront);
   }
   CUDA_CALL(cudaDeviceSynchronize());
@@ -57,9 +57,9 @@ double RunMinigun(const utils::SampleCsr& scsr,
 }
 
 double RunBaseline1(const utils::SampleCsr& scsr,
-                    const minigun::Csr& csr,
-                    mg_int feat_size, mg_int num_heads) {
-  const mg_int N = csr.row_offsets.length - 1;
+                    const minigun::IntCsr& csr,
+                    int32_t feat_size, int32_t num_heads) {
+  const int32_t N = csr.row_offsets.length - 1;
 
    // gdata
   GData gdata, truth;
@@ -68,7 +68,7 @@ double RunBaseline1(const utils::SampleCsr& scsr,
   InitGData(scsr, &gdata, &truth);
 
   // dry run
-  custom_kernel::vector_spmm_forward_kernel_no_eid<mg_int, float><<<N, 32>>>(
+  custom_kernel::vector_spmm_forward_kernel_no_eid<int32_t, float><<<N, 32>>>(
       csr.row_offsets.data,
       csr.column_indices.data,
       gdata.weight,
@@ -81,7 +81,7 @@ double RunBaseline1(const utils::SampleCsr& scsr,
   timeval t0, t1;
   gettimeofday(&t0, nullptr);
   for (int i = 0; i < K; ++i) {
-    custom_kernel::vector_spmm_forward_kernel_no_eid<mg_int, float><<<N, 32>>>(
+    custom_kernel::vector_spmm_forward_kernel_no_eid<int32_t, float><<<N, 32>>>(
         csr.row_offsets.data,
         csr.column_indices.data,
         gdata.weight,
@@ -113,12 +113,12 @@ int main(int argc, char** argv) {
 
   utils::SampleCsr scsr;
   utils::LoadGraphFromFile(filename, &scsr);
-  const mg_int N = scsr.row_offsets.size() - 1;
-  const mg_int M = scsr.column_indices.size();
+  const int32_t N = scsr.row_offsets.size() - 1;
+  const int32_t M = scsr.column_indices.size();
   std::cout << "#Nodes: " << N << " #Edges: " << M << std::endl;
 
   // csr
-  minigun::Csr csr = utils::ToMinigunCsr(scsr, kDLGPU);
+  minigun::IntCsr csr = utils::ToMinigunCsr(scsr, kDLGPU);
 
   double dur1 = RunMinigun(scsr, csr, feat_size, num_heads);
   std::cout << "minigun time(ms): " << dur1 << std::endl;

--- a/samples/edge_softmax/main.cc
+++ b/samples/edge_softmax/main.cc
@@ -9,7 +9,7 @@
 #include "../samples_utils.h"
 
 struct GData {
-  mg_int dim = 0;
+  int32_t dim = 0;
   float* sum{nullptr};  // ndata
   float* max{nullptr};  // ndata
   float* score{nullptr};
@@ -18,13 +18,13 @@ struct GData {
 // Max
 struct EdgeMax {
   static inline bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static inline void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
-    const mg_int dim = gdata->dim;
-    for (mg_int fid = 0; fid < dim; ++fid) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
+    const int32_t dim = gdata->dim;
+    for (int32_t fid = 0; fid < dim; ++fid) {
 #pragma omp critical
       gdata->max[dst * dim + fid] = std::max(gdata->max[dst * dim + fid],
           gdata->score[eid * dim + fid]);
@@ -35,13 +35,13 @@ struct EdgeMax {
 // minus max, exp and sum
 struct MinuxMaxExpSum {
   static inline bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static inline void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
-    const mg_int dim = gdata->dim;
-    for (mg_int fid = 0; fid < dim; ++fid) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
+    const int32_t dim = gdata->dim;
+    for (int32_t fid = 0; fid < dim; ++fid) {
       gdata->score[eid * dim + fid] = expf(gdata->score[eid * dim + fid] - gdata->max[dst * dim + fid]);
 #pragma omp atomic
       gdata->sum[dst * dim + fid] += gdata->score[eid * dim + fid];
@@ -52,23 +52,23 @@ struct MinuxMaxExpSum {
 // norm
 struct Norm {
   static inline bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static inline void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
-    const mg_int dim = gdata->dim;
-    for (mg_int fid = 0; fid < dim; ++fid) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
+    const int32_t dim = gdata->dim;
+    for (int32_t fid = 0; fid < dim; ++fid) {
       gdata->score[eid * dim + fid] /= gdata->sum[dst * dim + fid];
     }
   }
 };
 
-const mg_int D = 8;  // number of heads
+const int32_t D = 8;  // number of heads
 
 std::vector<float> GroundTruth(
-    const std::vector<mg_int>& row_offsets,
-    const std::vector<mg_int>& column_indices,
+    const std::vector<int32_t>& row_offsets,
+    const std::vector<int32_t>& column_indices,
     std::vector<float> score) {
   const size_t N = row_offsets.size() - 1;
   std::vector<float> tmp(N * D, 0.);
@@ -76,15 +76,15 @@ std::vector<float> GroundTruth(
     score[i] = std::exp(score[i]);
   }
   for (size_t u = 0; u < row_offsets.size() - 1; ++u) {
-    for (mg_int eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
-      mg_int v = column_indices[eid];
-      for (mg_int idx = 0; idx < D; ++idx) {
+    for (int32_t eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
+      int32_t v = column_indices[eid];
+      for (int32_t idx = 0; idx < D; ++idx) {
         tmp[v * D + idx] += score[eid * D + idx];
       }
     }
   }
   for (size_t eid = 0; eid < column_indices.size(); ++eid) {
-    for (mg_int i = 0; i < D; ++i) {
+    for (int32_t i = 0; i < D; ++i) {
       score[eid * D + i] /= tmp[column_indices[eid] * D + i];
     }
   }
@@ -95,16 +95,16 @@ int main(int argc, char** argv) {
   srand(42);
 
   // create graph
-  std::vector<mg_int> row_offsets, column_indices;
+  std::vector<int32_t> row_offsets, column_indices;
   utils::CreateNPGraph(1000, 0.01, row_offsets, column_indices);
-  const mg_int N = row_offsets.size() - 1;
-  const mg_int M = column_indices.size();
+  const int32_t N = row_offsets.size() - 1;
+  const int32_t M = column_indices.size();
   std::cout << "#nodes: " << N << " #edges: " << M
     << " #feats: " << D << std::endl;
 
   // copy graph to gpu
-  minigun::Csr csr;
-  minigun::IntArray1D infront;
+  minigun::IntCsr csr;
+  minigun::IntArray infront;
   csr.row_offsets.length = row_offsets.size();
   csr.row_offsets.data = &row_offsets[0];
   csr.column_indices.length = column_indices.size();
@@ -116,10 +116,10 @@ int main(int argc, char** argv) {
 
   // Create feature data
   std::vector<float> vvec(N * D), evec(M * D);
-  for (mg_int i = 0; i < N * D; ++i) {
+  for (int32_t i = 0; i < N * D; ++i) {
     vvec[i] = std::numeric_limits<float>::lowest();
   }
-  for (mg_int i = 0; i < M * D; ++i) {
+  for (int32_t i = 0; i < M * D; ++i) {
     evec[i] = (float)rand() / RAND_MAX - 0.5;
   }
   //utils::VecPrint(evec);
@@ -137,11 +137,11 @@ int main(int argc, char** argv) {
   //utils::VecPrint(truth);
 
   typedef minigun::advance::Config<true, minigun::advance::kV2N> Config;
-  minigun::advance::Advance<kDLCPU, Config, GData, EdgeMax>(
+  minigun::advance::Advance<kDLCPU, int32_t, Config, GData, EdgeMax>(
       config, csr, &gdata, infront);
-  minigun::advance::Advance<kDLCPU, Config, GData, MinuxMaxExpSum>(
+  minigun::advance::Advance<kDLCPU, int32_t, Config, GData, MinuxMaxExpSum>(
       config, csr, &gdata, infront);
-  minigun::advance::Advance<kDLCPU, Config, GData, Norm>(
+  minigun::advance::Advance<kDLCPU, int32_t, Config, GData, Norm>(
       config, csr, &gdata, infront);
 
   // verify output
@@ -149,21 +149,21 @@ int main(int argc, char** argv) {
 
   const int K = 10;
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, EdgeMax>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, EdgeMax>(
         config, csr, &gdata, infront);
-    minigun::advance::Advance<kDLCPU, Config, GData, MinuxMaxExpSum>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, MinuxMaxExpSum>(
         config, csr, &gdata, infront);
-    minigun::advance::Advance<kDLCPU, Config, GData, Norm>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, Norm>(
         config, csr, &gdata, infront);
   }
 
   auto start = std::chrono::system_clock::now();
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, EdgeMax>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, EdgeMax>(
         config, csr, &gdata, infront);
-    minigun::advance::Advance<kDLCPU, Config, GData, MinuxMaxExpSum>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, MinuxMaxExpSum>(
         config, csr, &gdata, infront);
-    minigun::advance::Advance<kDLCPU, Config, GData, Norm>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, Norm>(
         config, csr, &gdata, infront);
   }
   auto end = std::chrono::system_clock::now();

--- a/samples/masked_mm/main.cc
+++ b/samples/masked_mm/main.cc
@@ -8,22 +8,22 @@
 #include "../samples_utils.h"
 
 struct GData {
-  mg_int dim = 0;
+  int32_t dim = 0;
   float* ndata{nullptr};
   float* edata{nullptr};
 };
 
 struct MaskedMMFunctor {
   static inline bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static inline void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     // only one block along the data dim
-    const mg_int dim = gdata->dim;
+    const int32_t dim = gdata->dim;
     float sum = 0.;
-    for (mg_int fid = 0; fid < dim; ++fid) {
+    for (int32_t fid = 0; fid < dim; ++fid) {
       sum += gdata->ndata[src * dim + fid] * gdata->ndata[dst * dim + fid];
     }
 #pragma omp atomic
@@ -31,17 +31,17 @@ struct MaskedMMFunctor {
   }
 };
 
-const mg_int D = 128;  // number of features
+const int32_t D = 128;  // number of features
 
 std::vector<float> GroundTruth(
-    const std::vector<mg_int>& row_offsets,
-    const std::vector<mg_int>& column_indices,
+    const std::vector<int32_t>& row_offsets,
+    const std::vector<int32_t>& column_indices,
     const std::vector<float>& vdata) {
   std::vector<float> ret(column_indices.size(), 0);
   for (size_t u = 0; u < row_offsets.size() - 1; ++u) {
-    for (mg_int eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
-      mg_int v = column_indices[eid];
-      for (mg_int idx = 0; idx < D; ++idx) {
+    for (int32_t eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
+      int32_t v = column_indices[eid];
+      for (int32_t idx = 0; idx < D; ++idx) {
         ret[eid] += vdata[u * D + idx] * vdata[v * D + idx];
       }
     }
@@ -53,16 +53,16 @@ int main(int argc, char** argv) {
   srand(42);
 
   // create graph
-  std::vector<mg_int> row_offsets, column_indices;
+  std::vector<int32_t> row_offsets, column_indices;
   utils::CreateNPGraph(1000, 0.01, row_offsets, column_indices);
-  const mg_int N = row_offsets.size() - 1;
-  const mg_int M = column_indices.size();
+  const int32_t N = row_offsets.size() - 1;
+  const int32_t M = column_indices.size();
   std::cout << "#nodes: " << N << " #edges: " << M
     << " #feats: " << D << std::endl;
 
   // copy graph to gpu
-  minigun::Csr csr;
-  minigun::IntArray1D infront;
+  minigun::IntCsr csr;
+  minigun::IntArray infront;
   csr.row_offsets.length = row_offsets.size();
   csr.row_offsets.data = &row_offsets[0];
   csr.column_indices.length = column_indices.size();
@@ -74,10 +74,10 @@ int main(int argc, char** argv) {
 
   // Create feature data
   std::vector<float> vvec(N * D), evec(M);
-  for (mg_int i = 0; i < N * D; ++i) {
+  for (int32_t i = 0; i < N * D; ++i) {
     vvec[i] = (float)rand() / RAND_MAX;
   }
-  for (mg_int i = 0; i < M; ++i) {
+  for (int32_t i = 0; i < M; ++i) {
     evec[i] = 0.;
   }
 
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
   //utils::VecPrint(truth);
 
   typedef minigun::advance::Config<true, minigun::advance::kV2N> Config;
-  minigun::advance::Advance<kDLCPU, Config, GData, MaskedMMFunctor>(
+  minigun::advance::Advance<kDLCPU, int32_t, Config, GData, MaskedMMFunctor>(
       config, csr, &gdata, infront);
 
   // verify output
@@ -100,13 +100,13 @@ int main(int argc, char** argv) {
 
   const int K = 10;
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, MaskedMMFunctor>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, MaskedMMFunctor>(
         config, csr, &gdata, infront);
   }
 
   auto start = std::chrono::system_clock::now();
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, MaskedMMFunctor>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, MaskedMMFunctor>(
         config, csr, &gdata, infront);
   }
   auto end = std::chrono::system_clock::now();

--- a/samples/samples_utils.h
+++ b/samples/samples_utils.h
@@ -47,13 +47,13 @@ bool IterEqual(Iter1 v1, Iter2 v2, size_t count) {
   return true;
 }
 
-__inline__ void CreateNPGraph(int64_t N, float P,
-    std::vector<mg_int>& row_offsets,
-    std::vector<mg_int>& column_indices) {
+inline void CreateNPGraph(int64_t N, float P,
+    std::vector<int32_t>& row_offsets,
+    std::vector<int32_t>& column_indices) {
   row_offsets.resize(N+1, 0);
   row_offsets[0] = 0;
-  for (mg_int u = 0; u < N; ++u) {
-    for (mg_int v = 0; v < N; ++v) {
+  for (int32_t u = 0; u < N; ++u) {
+    for (int32_t v = 0; v < N; ++v) {
       if ((float)rand() / RAND_MAX < P) {
         column_indices.push_back(v);
       }

--- a/samples/spmm/full.cc
+++ b/samples/spmm/full.cc
@@ -8,7 +8,7 @@
 #include "../samples_utils.h"
 
 struct GData {
-  mg_int dim = 0;
+  int32_t dim = 0;
   float* cur{nullptr};
   float* next{nullptr};
   float* weight{nullptr};
@@ -16,12 +16,12 @@ struct GData {
 
 struct SPMMFunctor {
   static inline bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static inline void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
-    for (mg_int fid = 0; fid < gdata->dim; ++fid) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
+    for (int32_t fid = 0; fid < gdata->dim; ++fid) {
 #pragma omp atomic
       gdata->next[dst * gdata->dim + fid] += gdata->cur[src * gdata->dim + fid] *
         gdata->weight[eid];
@@ -29,18 +29,18 @@ struct SPMMFunctor {
   }
 };
 
-const mg_int D = 128;  // number of features
+const int32_t D = 128;  // number of features
 
 std::vector<float> GroundTruth(
-    const std::vector<mg_int>& row_offsets,
-    const std::vector<mg_int>& column_indices,
+    const std::vector<int32_t>& row_offsets,
+    const std::vector<int32_t>& column_indices,
     const std::vector<float>& vdata,
     const std::vector<float>& edata) {
   std::vector<float> ret(vdata.size(), 0);
   for (size_t u = 0; u < row_offsets.size() - 1; ++u) {
-    for (mg_int eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
-      mg_int v = column_indices[eid];
-      for (mg_int idx = 0; idx < D; ++idx) {
+    for (int32_t eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
+      int32_t v = column_indices[eid];
+      for (int32_t idx = 0; idx < D; ++idx) {
         ret[v * D + idx] += vdata[u * D + idx] * edata[eid];
       }
     }
@@ -52,16 +52,16 @@ int main(int argc, char** argv) {
   srand(42);
 
   // create graph
-  std::vector<mg_int> row_offsets, column_indices;
+  std::vector<int32_t> row_offsets, column_indices;
   utils::CreateNPGraph(1000, 0.01, row_offsets, column_indices);
-  const mg_int N = row_offsets.size() - 1;
-  const mg_int M = column_indices.size();
+  const int32_t N = row_offsets.size() - 1;
+  const int32_t M = column_indices.size();
   std::cout << "#nodes: " << N << " #edges: " << M
     << " #feats: " << D << std::endl;
 
   // copy graph to gpu
-  minigun::Csr csr;
-  minigun::IntArray1D infront;
+  minigun::IntCsr csr;
+  minigun::IntArray infront;
   csr.row_offsets.length = row_offsets.size();
   csr.row_offsets.data = &row_offsets[0];
   csr.column_indices.length = column_indices.size();
@@ -73,10 +73,10 @@ int main(int argc, char** argv) {
 
   // Create feature data
   std::vector<float> vvec(N * D), evec(M);
-  for (mg_int i = 0; i < N * D; ++i) {
+  for (int32_t i = 0; i < N * D; ++i) {
     vvec[i] = (float)rand() / RAND_MAX;
   }
-  for (mg_int i = 0; i < M; ++i) {
+  for (int32_t i = 0; i < M; ++i) {
     evec[i] = (float)rand() / RAND_MAX;
   }
 
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
       vvec, evec);
 
   typedef minigun::advance::Config<true, minigun::advance::kV2N> Config;
-  minigun::advance::Advance<kDLCPU, Config, GData, SPMMFunctor>(
+  minigun::advance::Advance<kDLCPU, int32_t, Config, GData, SPMMFunctor>(
       config, csr, &gdata, infront, nullptr,
       utils::CPUAllocator::Get());
 
@@ -102,14 +102,14 @@ int main(int argc, char** argv) {
 
   const int K = 10;
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, SPMMFunctor>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, SPMMFunctor>(
         config, csr, &gdata, infront, nullptr,
         utils::CPUAllocator::Get());
   }
 
   auto start = std::chrono::system_clock::now();
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, SPMMFunctor>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, SPMMFunctor>(
         config, csr, &gdata, infront, nullptr,
         utils::CPUAllocator::Get());
   }

--- a/samples/spmm/full.cu
+++ b/samples/spmm/full.cu
@@ -8,7 +8,7 @@
 #include "../samples_utils.h"
 
 struct GData {
-  mg_int dim = 0;
+  int32_t dim = 0;
   float* cur{nullptr};
   float* next{nullptr};
   float* weight{nullptr};
@@ -16,13 +16,13 @@ struct GData {
 
 struct SPMMFunctor {
   static __device__ __forceinline__ bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static __device__ __forceinline__ void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
-    mg_int tx = blockIdx.x * blockDim.x + threadIdx.x;
-    mg_int stride_x = blockDim.x * gridDim.x;
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
+    int32_t tx = blockIdx.x * blockDim.x + threadIdx.x;
+    int32_t stride_x = blockDim.x * gridDim.x;
     while (tx < gdata->dim) {
       atomicAdd(gdata->next + dst * gdata->dim + tx,
                 gdata->cur[src * gdata->dim + tx] * gdata->weight[eid]);
@@ -31,18 +31,18 @@ struct SPMMFunctor {
   }
 };
 
-const mg_int D = 128;  // number of features
+const int32_t D = 128;  // number of features
 
 std::vector<float> GroundTruth(
-    const std::vector<mg_int>& row_offsets,
-    const std::vector<mg_int>& column_indices,
+    const std::vector<int32_t>& row_offsets,
+    const std::vector<int32_t>& column_indices,
     const std::vector<float>& vdata,
     const std::vector<float>& edata) {
   std::vector<float> ret(vdata.size(), 0);
   for (size_t u = 0; u < row_offsets.size() - 1; ++u) {
-    for (mg_int eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
-      mg_int v = column_indices[eid];
-      for (mg_int idx = 0; idx < D; ++idx) {
+    for (int32_t eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
+      int32_t v = column_indices[eid];
+      for (int32_t idx = 0; idx < D; ++idx) {
         ret[v * D + idx] += vdata[u * D + idx] * edata[eid];
       }
     }
@@ -54,25 +54,25 @@ int main(int argc, char** argv) {
   srand(42);
 
   // create graph
-  std::vector<mg_int> row_offsets, column_indices;
+  std::vector<int32_t> row_offsets, column_indices;
   utils::CreateNPGraph(1000, 0.01, row_offsets, column_indices);
-  const mg_int N = row_offsets.size() - 1;
-  const mg_int M = column_indices.size();
+  const int32_t N = row_offsets.size() - 1;
+  const int32_t M = column_indices.size();
   std::cout << "#nodes: " << N << " #edges: " << M
     << " #feats: " << D << std::endl;
 
   // copy graph to gpu
   CUDA_CALL(cudaSetDevice(0));
-  minigun::Csr csr;
-  minigun::IntArray1D infront;
+  minigun::IntCsr csr;
+  minigun::IntArray infront;
   csr.row_offsets.length = row_offsets.size();
-  CUDA_CALL(cudaMalloc(&csr.row_offsets.data, sizeof(mg_int) * row_offsets.size()));
+  CUDA_CALL(cudaMalloc(&csr.row_offsets.data, sizeof(int32_t) * row_offsets.size()));
   CUDA_CALL(cudaMemcpy(csr.row_offsets.data, &row_offsets[0],
-        sizeof(mg_int) * row_offsets.size(), cudaMemcpyHostToDevice));
+        sizeof(int32_t) * row_offsets.size(), cudaMemcpyHostToDevice));
   csr.column_indices.length = column_indices.size();
-  CUDA_CALL(cudaMalloc(&csr.column_indices.data, sizeof(mg_int) * column_indices.size()));
+  CUDA_CALL(cudaMalloc(&csr.column_indices.data, sizeof(int32_t) * column_indices.size()));
   CUDA_CALL(cudaMemcpy(csr.column_indices.data, &column_indices[0],
-        sizeof(mg_int) * column_indices.size(), cudaMemcpyHostToDevice));
+        sizeof(int32_t) * column_indices.size(), cudaMemcpyHostToDevice));
 
   // Create stream
   minigun::advance::RuntimeConfig config;
@@ -84,10 +84,10 @@ int main(int argc, char** argv) {
 
   // Create feature data
   std::vector<float> vvec(N * D), evec(M);
-  for (mg_int i = 0; i < N * D; ++i) {
+  for (int32_t i = 0; i < N * D; ++i) {
     vvec[i] = (float)rand() / RAND_MAX;
   }
-  for (mg_int i = 0; i < M; ++i) {
+  for (int32_t i = 0; i < M; ++i) {
     evec[i] = (float)rand() / RAND_MAX;
   }
 
@@ -108,7 +108,7 @@ int main(int argc, char** argv) {
       vvec, evec);
 
   typedef minigun::advance::Config<true, minigun::advance::kV2N> Config;
-  minigun::advance::Advance<kDLGPU, Config, GData, SPMMFunctor>(
+  minigun::advance::Advance<kDLGPU, int32_t, Config, GData, SPMMFunctor>(
       config, csr, &gdata, infront, nullptr);
 
   CUDA_CALL(cudaDeviceSynchronize());

--- a/samples/spmv/full.cc
+++ b/samples/spmv/full.cc
@@ -15,25 +15,25 @@ struct GData {
 
 struct SPMVFunctor {
   static inline bool CondEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
     return true;
   }
   static inline void ApplyEdge(
-      mg_int src, mg_int dst, mg_int eid, GData* gdata) {
+      int32_t src, int32_t dst, int32_t eid, GData* gdata) {
 #pragma omp atomic
     gdata->next[dst] += gdata->cur[src] * gdata->weight[eid];
   }
 };
 
 std::vector<float> GroundTruth(
-    const std::vector<mg_int>& row_offsets,
-    const std::vector<mg_int>& column_indices,
+    const std::vector<int32_t>& row_offsets,
+    const std::vector<int32_t>& column_indices,
     const std::vector<float>& vdata,
     const std::vector<float>& edata) {
   std::vector<float> ret(vdata.size(), 0);
   for (size_t u = 0; u < row_offsets.size() - 1; ++u) {
-    for (mg_int eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
-      mg_int v = column_indices[eid];
+    for (int32_t eid = row_offsets[u]; eid < row_offsets[u+1]; ++eid) {
+      int32_t v = column_indices[eid];
       ret[v] += vdata[u] * edata[eid];
     }
   }
@@ -42,14 +42,14 @@ std::vector<float> GroundTruth(
 
 int main(int argc, char** argv) {
   srand(42);
-  std::vector<mg_int> row_offsets, column_indices;
+  std::vector<int32_t> row_offsets, column_indices;
   utils::CreateNPGraph(1000, 0.01, row_offsets, column_indices);
-  const mg_int N = row_offsets.size() - 1;
-  const mg_int M = column_indices.size();
+  const int32_t N = row_offsets.size() - 1;
+  const int32_t M = column_indices.size();
   std::cout << "#nodes: " << N << " #edges: " << M << std::endl;
 
-  minigun::Csr csr;
-  minigun::IntArray1D infront;
+  minigun::IntCsr csr;
+  minigun::IntArray infront;
   csr.row_offsets.length = row_offsets.size();
   csr.row_offsets.data = &row_offsets[0];
   csr.column_indices.length = column_indices.size();
@@ -61,10 +61,10 @@ int main(int argc, char** argv) {
 
   // Create vdata, edata and copy to GPU
   std::vector<float> vvec(N), evec(M);
-  for (mg_int i = 0; i < N; ++i) {
+  for (int32_t i = 0; i < N; ++i) {
     vvec[i] = (float)rand() / RAND_MAX;
   }
-  for (mg_int i = 0; i < M; ++i) {
+  for (int32_t i = 0; i < M; ++i) {
     evec[i] = (float)rand() / RAND_MAX;
   }
 
@@ -80,7 +80,7 @@ int main(int argc, char** argv) {
   //utils::VecPrint(truth);
 
   typedef minigun::advance::Config<true, minigun::advance::kV2N> Config;
-  minigun::advance::Advance<kDLCPU, Config, GData, SPMVFunctor>(
+  minigun::advance::Advance<kDLCPU, int32_t, Config, GData, SPMVFunctor>(
       config, csr, &gdata, infront, nullptr,
       utils::CPUAllocator::Get());
 
@@ -89,14 +89,14 @@ int main(int argc, char** argv) {
 
   const int K = 10;
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, SPMVFunctor>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, SPMVFunctor>(
         config, csr, &gdata, infront, nullptr,
         utils::CPUAllocator::Get());
   }
 
   auto start = std::chrono::system_clock::now();
   for (int i = 0; i < K; ++i) {
-    minigun::advance::Advance<kDLCPU, Config, GData, SPMVFunctor>(
+    minigun::advance::Advance<kDLCPU, int32_t, Config, GData, SPMVFunctor>(
         config, csr, &gdata, infront, nullptr,
         utils::CPUAllocator::Get());
   }

--- a/scripts/graph_io.py
+++ b/scripts/graph_io.py
@@ -2,26 +2,23 @@ import struct
 import numpy as np
 import scipy.sparse as sp
 
-# assume mg_int is int64_t
 # return a scipy.sparse.csr_matrix
-# NOTE: scipy currently does not support int64 indices, all int64 will be casted to int32
 def load_graph(filename):
     with open(filename, 'rb') as f:
         l = struct.unpack('q', f.read(8))[0]
-        indptr = np.frombuffer(f.read(l * 8), dtype=np.int64)
+        indptr = np.frombuffer(f.read(l * 8), dtype=np.int32)
         l = struct.unpack('q', f.read(8))[0]
-        indices = np.frombuffer(f.read(l * 8), dtype=np.int64)
+        indices = np.frombuffer(f.read(l * 8), dtype=np.int32)
         N = indptr.shape[0] - 1
         M = indices.shape[0]
         data = np.ones((M,), dtype=np.float32)
         return sp.csr_matrix((data, indices, indptr), shape=(N, N), dtype=np.float32)
 
-# assume mg_int is int64_t
+# assume mg_int is int32_t
 # g is in scipy.sparse.csr_matrix
-# NOTE: scipy currently does not support int64 indices, all int64 will be casted to int32
 def save_graph(filename, g):
     with open(filename, 'wb') as f:
         f.write(struct.pack('q', g.indptr.shape[0]))
-        f.write(g.indptr.astype(np.int64).tobytes())
+        f.write(g.indptr.astype(np.int32).tobytes())
         f.write(struct.pack('q', g.indices.shape[0]))
-        f.write(g.indices.astype(np.int64).tobytes())
+        f.write(g.indices.astype(np.int32).tobytes())


### PR DESCRIPTION
This change allows minigun to support graph stored in int32_t or others.

TODO: We should further refactor the template arguments so that
 (1) All static configuration are included in `minigun::advance::Config`.
 (2) All other template arguments could be automatically deduced from the function arguments, so we don't need to explicitly specify them.